### PR TITLE
Ensure that the dependency map is rendered in a deterministic order.

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,12 +111,13 @@ function renderBundle(options, cb) {
       "})({";
 
     modules.forEach(function(canonicalSourcePath) {
+      var thisDepMap = depMap[canonicalSourcePath];
       out += aliases[canonicalSourcePath] + ": [function(require,module,exports,global){\n";
       if (canonicalSourcePath.match(/\.json$/)) {
         out += "module.exports = ";
       }
       out += sources[canonicalSourcePath];
-      out += "\n}, " + JSON.stringify(depMap[canonicalSourcePath]) + "],";
+      out += "\n}, " + JSON.stringify(thisDepMap, Object.keys(thisDepMap).sort()) + "],";
     });
 
     out += "}, {}, " + aliases[entrySourcePath] + ");\n";


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org) I noticed that browserify-lite generates unreproducible output. I tracked this down to `JSON.stringify` not ordering its result by default, resulting in output such as:

```
-    "./foo": 2,
-    "./bar": 1
+    "./bar": 1,
+    "./foo": 2
```

This commit sorts the results so that the build is the same each time.